### PR TITLE
Handle the case where the RSS feed does not include a protocol scheme.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	if u.Scheme == "" {
+		w.WriteHeader(400)
+		if _, err := w.Write([]byte("RSS url needs to include a protocol scheme")); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 	feed, err := parseFeedFromUrl(u)
 	if err != nil {
 		w.WriteHeader(400)

--- a/rss_test.go
+++ b/rss_test.go
@@ -80,6 +80,18 @@ func TestParseRSS(t *testing.T) {
 		}
 	})
 
+	t.Run("test rss url without protocol scheme", func(t *testing.T) {
+		r := httptest.NewRequest(
+			http.MethodPost,
+			"/",
+			strings.NewReader("www.test.com"))
+		w := httptest.NewRecorder()
+		requestHandler(w, r)
+		if w.Result().StatusCode != 400 {
+			t.Fatal("Status code returned was not 400 when RSS url was missing the protocol scheme")
+		}
+	})
+
 	t.Run("test invalid RSS feed", func(t *testing.T) {
 		r := httptest.NewRequest(
 			http.MethodPost,


### PR DESCRIPTION
Golang HTTP client requires the protocol scheme which is an ok requirement so this handles the situation where no protocol scheme is included in the rss url.