### PR TITLE
Handle non existing domain in a more robust way

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -32,7 +32,7 @@ func parseFeedFromXML(rssXml []byte) (Feed, error) {
 func parseFeedFromUrl(rssFeedUrl *url.URL) (Feed, error) {
 	resp, err := http.Get(rssFeedUrl.String())
 	if err != nil {
-		log.Fatal(err)
+		return Feed{}, err
 	}
 	if resp.StatusCode != 200 {
 		return Feed{}, errors.New("url did not return statusCode 200")

--- a/rss_test.go
+++ b/rss_test.go
@@ -65,18 +65,17 @@ func TestParseRSS(t *testing.T) {
 	})
 
 	t.Run("test invalid rss url", func(t *testing.T) {
-		r := httptest.NewRequest(
-			http.MethodPost,
-			"/",
-			strings.NewReader("this :// is not a url"))
-		w := httptest.NewRecorder()
-		requestHandler(w, r)
-		if w.Result().StatusCode != 400 {
-			t.Fatal("Status code returned was not 400")
-		}
-		content, _ := io.ReadAll(w.Result().Body)
-		if string(content) != "error in request, url passed in body was not valid" {
-			t.Fatal("Message returned was incorrect")
+		invalidUrls := []string{"this :// is not a url", "https://en.wikipe"}
+		for _, invalidUrl := range invalidUrls {
+			r := httptest.NewRequest(
+				http.MethodPost,
+				"/",
+				strings.NewReader(invalidUrl))
+			w := httptest.NewRecorder()
+			requestHandler(w, r)
+			if w.Result().StatusCode != 400 {
+				t.Fatal("Status code returned was not 400")
+			}
 		}
 	})
 


### PR DESCRIPTION
The previous implementation did a log.Fatal if a non existent domain
name was passed in. Tests added shows example of a partial wikipedia
domain that cause the process to exit.